### PR TITLE
Genarate separete APKs for  ARM and x86

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -75,12 +75,12 @@ apply from: "../../node_modules/react-native/react.gradle"
  * Upload all the APKs to the Play Store and people will download
  * the correct one based on the CPU architecture of their device.
  */
-def enableSeparateBuildPerCPUArchitecture = false
+def enableSeparateBuildPerCPUArchitecture = true
 
 /**
  * Run Proguard to shrink the Java bytecode in release builds.
  */
-def enableProguardInReleaseBuilds = false
+def enableProguardInReleaseBuilds = true
 
 android {
     compileSdkVersion 23


### PR DESCRIPTION
Create two separate APKs instead of one:
  - An APK that only works on ARM devices
  - An APK that only works on x86 devices

The advantage is the size of the APK is reduced by about 4MB. Upload all the APKs to the Play Store and people will download the correct one based on the CPU architecture of their device.